### PR TITLE
Improves fee creation and selection

### DIFF
--- a/src/components/features/fee-select.tsx
+++ b/src/components/features/fee-select.tsx
@@ -87,7 +87,18 @@ export const FeeSelect = ({
         end_time: new Date(new Date().setFullYear(new Date().getFullYear() + 1)),
       };
 
-      await handleCreateFee(newFee as Fee);
+      const result = await handleCreateFee(newFee as Fee);
+      
+      // Auto-select the newly created fee
+      if (result && 'payload' in result && result.payload) {
+        const createdFee = result.payload as Fee;
+        const feeId = createdFee.id?.toString();
+        if (feeId) {
+          setSelectedValue(feeId);
+          onSelect(createdFee);
+        }
+      }
+      
       toast.success('Tạo học phí mới thành công');
       setIsNewFeeDialogOpen(false);
       feeForm.reset();

--- a/src/hooks/useFee.ts
+++ b/src/hooks/useFee.ts
@@ -27,7 +27,7 @@ export const useFee = () => {
 
   const handleCreateFee = useCallback(
     (fee: Fee) => {
-      dispatch(createFee(fee));
+      return dispatch(createFee(fee));
     },
     [dispatch]
   );


### PR DESCRIPTION
Automatically selects the newly created fee in the UI after it's created.

This change enhances user experience by immediately reflecting the new fee in the selection dropdown after successful creation, removing the need for manual selection.

It also updates the `handleCreateFee` function to return the dispatched action. This is required to be able to access the created fee data.